### PR TITLE
Markdown it

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,16 +145,19 @@
     "package": "vsce package"
   },
   "devDependencies": {
-    "@types/vscode": "^1.64.0",
     "@types/glob": "^7.2.0",
     "@types/mocha": "^9.1.0",
     "@types/node": "14.x",
+    "@types/vscode": "^1.64.0",
     "@typescript-eslint/eslint-plugin": "^5.12.1",
     "@typescript-eslint/parser": "^5.12.1",
+    "@vscode/test-electron": "^2.1.2",
     "eslint": "^8.9.0",
     "glob": "^7.2.0",
     "mocha": "^9.2.1",
-    "typescript": "^4.5.5",
-    "@vscode/test-electron": "^2.1.2"
+    "typescript": "^4.5.5"
+  },
+  "dependencies": {
+    "markdown-it": "^13.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",
+    "@types/markdown-it": "^12.2.3",
     "@types/mocha": "^9.1.0",
     "@types/node": "14.x",
     "@types/vscode": "^1.64.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -95,14 +95,12 @@ const headerFilter = (block: Token, params: FilterParams): boolean => {
   if (block.level !== 0 || block.type !== 'heading_open') {
     return false;
   }
-  console.log(`looking at: ${JSON.stringify(block)}`);
 
   // we need a line number
   if (block.map?.[0] === undefined) {
     return false;
   }
   const lineNumber = block.map[0];
-  console.log(`lineNumber = ${lineNumber}`);
 
   if (minLine !== undefined && lineNumber < minLine) {
     return false;
@@ -116,7 +114,6 @@ const headerFilter = (block: Token, params: FilterParams): boolean => {
   if (ignoreCurrent && currentLine !== undefined && lineNumber === currentLine) {
     return false;
   }
-  console.log(`made it past the line number filters`);
 
   // The tag must be of the form "h<digit>"
   if (!block.tag.match(/^h\d$/)) {
@@ -131,7 +128,6 @@ const headerFilter = (block: Token, params: FilterParams): boolean => {
   if (exactLevel && headerLevel !== exactLevel) {
     return false;
   }
-  console.log(`all good! returning true!`);
 
   return true;
 };
@@ -148,7 +144,6 @@ const findHeader = (editor: vscode.TextEditor, { direction = 1, ignoreCurrent = 
   } else {
     currentLine = startLine;
   }
-  console.log(`findHeader, currentLine = ${currentLine}`);
   let parsed = getBlocks(editor);
   const filterParams: FilterParams = { ignoreCurrent, minLevel, exactLevel, currentLine };
   if (direction === -1) {
@@ -157,11 +152,8 @@ const findHeader = (editor: vscode.TextEditor, { direction = 1, ignoreCurrent = 
   } else {
     filterParams.minLine = currentLine;
   }
-  console.log(`headers: ${JSON.stringify(parsed.filter(b => b.type === 'heading_open'))}`);
   const header = parsed.find(block => headerFilter(block, filterParams));
-  console.log(`found header: ${JSON.stringify(header)}\nfilterParams = ${JSON.stringify(filterParams)}`);
   if (header?.map) {
-    console.log(`returning ${header.map[0]}`);
     return header.map[0];
   }
   return -1;
@@ -169,21 +161,17 @@ const findHeader = (editor: vscode.TextEditor, { direction = 1, ignoreCurrent = 
 
 let gotoHeader = (editor: vscode.TextEditor, params: { direction: 1 | -1, minLevel?: number, exactLevel?: number }) => {
   const { direction, minLevel, exactLevel } = params;
-  console.log(`gotoHeader, direction = ${direction}, minLevel = ${minLevel}, exactLevel = ${exactLevel}`);
   const headerLine = findHeader(editor, { direction, ignoreCurrent: true, minLevel, exactLevel });
 
   if (headerLine >= 0) {
-    console.log(`found header at line ${headerLine}`);
     const position = editor.selection.active;
     var newPosition = new vscode.Position(headerLine, 0);
     var newSelection: vscode.Selection;
     var range: vscode.Range;
     if (editor.selection.isEmpty) {
-      console.log(`no previous selection`);
       newSelection = new vscode.Selection(newPosition, newPosition);
       range = new vscode.Range(newPosition, newPosition);
     } else {
-      console.log(`expanding selection`);
       if (direction === -1) {
         newSelection = new vscode.Selection(editor.selection.end, newPosition);
       } else {
@@ -278,7 +266,6 @@ const moveAllDoneToBottom = async function (editor: vscode.TextEditor) {
   let maxLine = editor.document.lineCount - 1;
   let haveSelection = false;
   if (editor.selection.start.line !== editor.selection.end.line) {
-    console.log(`we have a selection`);
     minLine = editor.selection.start.line;
     maxLine = editor.selection.end.line;
     haveSelection = true;
@@ -301,7 +288,6 @@ const moveAllDoneToBottom = async function (editor: vscode.TextEditor) {
       1000
     );
   }
-  console.log(`firstLine: ${minLine}, lastLine: ${maxLine}, min header level: ${topLevelHeader}`);
   headers = headers.filter(header => getHeaderLevel(header) === topLevelHeader);
 
   // get a list of the line ranges for all top-level DONE entries

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,7 +88,7 @@ type FilterParams = {
 };
 
 const headerFilter = (block: Token, params: FilterParams): boolean => {
-  const { ignoreCurrent, minLevel, exactLevel } = params;
+  const { ignoreCurrent, minLevel, exactLevel, currentLine, minLine, maxLine } = params;
   // must be a top-level header
   // top-level means "not nested inside of another thing". An h2 header can be a top-level header.
   // For example, a header inside of a blockquote or a list is not top-level.
@@ -104,16 +104,16 @@ const headerFilter = (block: Token, params: FilterParams): boolean => {
   const lineNumber = block.map[0];
   console.log(`lineNumber = ${lineNumber}`);
 
-  if (params.minLine !== undefined && lineNumber < params.minLine) {
+  if (minLine !== undefined && lineNumber < minLine) {
     return false;
   }
 
-  if (params.maxLine !== undefined && lineNumber > params.maxLine) {
+  if (maxLine !== undefined && lineNumber > maxLine) {
     return false;
   }
 
   // if we're ignoring the current line, then return if it's the same line
-  if (ignoreCurrent && params.currentLine !== undefined && lineNumber === params.currentLine) {
+  if (ignoreCurrent && currentLine !== undefined && lineNumber === currentLine) {
     return false;
   }
   console.log(`made it past the line number filters`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,7 +79,6 @@ const deleteCompletedAt = (editor: vscode.TextEditor, editBuilder: vscode.TextEd
 //
 // We're looking for headers that have a level of 0. The first entry in the `map` attribute is the line index of the header.
 type FilterParams = {
-  direction: number;
   ignoreCurrent: boolean;
   minLevel?: number;
   exactLevel?: number;
@@ -89,7 +88,7 @@ type FilterParams = {
 };
 
 const headerFilter = (block: Token, params: FilterParams): boolean => {
-  const { direction, ignoreCurrent, minLevel, exactLevel } = params;
+  const { ignoreCurrent, minLevel, exactLevel } = params;
   // must be a top-level header
   // top-level means "not nested inside of another thing". An h2 header can be a top-level header.
   // For example, a header inside of a blockquote or a list is not top-level.
@@ -151,7 +150,7 @@ const findHeader = (editor: vscode.TextEditor, { direction = 1, ignoreCurrent = 
   }
   console.log(`findHeader, currentLine = ${currentLine}`);
   let parsed = getBlocks(editor);
-  const filterParams: FilterParams = { direction, ignoreCurrent, minLevel, exactLevel, currentLine };
+  const filterParams: FilterParams = { ignoreCurrent, minLevel, exactLevel, currentLine };
   if (direction === -1) {
     parsed = parsed.reverse();
     filterParams.maxLine = currentLine;
@@ -287,7 +286,7 @@ const moveAllDoneToBottom = async function (editor: vscode.TextEditor) {
 
   let parsed = getBlocks(editor);
 
-  const filterParams: FilterParams = { direction: 1, ignoreCurrent: false, minLine, maxLine };
+  const filterParams: FilterParams = { ignoreCurrent: false, minLine, maxLine };
   let headers = parsed.filter(block => headerFilter(block, filterParams));
   let topLevelHeader = 1;
   if (haveSelection) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -438,6 +438,11 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+entities@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
+  integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
+
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -855,6 +860,13 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+linkify-it@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-4.0.0.tgz#4f2d16879adc637cdfe9056cbc02de30e88ffa32"
+  integrity sha512-QAxkXyzT/TXgwGyY4rTgC95Ex6/lZ5/lYTV9nug6eJt93BCBQGOE47D/g2+/m5J1MrVLr2ot97OXkBZ9bBpR4A==
+  dependencies:
+    uc.micro "^1.0.1"
+
 listenercount@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/listenercount/-/listenercount-1.0.1.tgz#84c8a72ab59c4725321480c975e6508342e70937"
@@ -886,6 +898,22 @@ lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+markdown-it@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-13.0.0.tgz#f0803ded286980dc9f35972dad159cc4e64848f6"
+  integrity sha512-WArlIpVFvVwb8t3wgJuOsbMLhNWlzuQM7H2qXmuUEnBtXRqKjLjwFUMbZOyJgHygVZSjvcLR4EcXcRilqMavrA==
+  dependencies:
+    argparse "^2.0.1"
+    entities "~3.0.1"
+    linkify-it "^4.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
@@ -1267,6 +1295,11 @@ typescript@^4.5.5:
   version "4.5.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 unzipper@^0.10.11:
   version "0.10.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -70,6 +70,24 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/linkify-it@*":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@types/linkify-it/-/linkify-it-3.0.2.tgz#fd2cd2edbaa7eaac7e7f3c1748b52a19143846c9"
+  integrity sha512-HZQYqbiFVWufzCwexrvh694SOim8z2d+xJl5UNamcvQFejLY/2YUtzXHYi3cHdI7PMlS8ejH2slRAOJQ32aNbA==
+
+"@types/markdown-it@^12.2.3":
+  version "12.2.3"
+  resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-12.2.3.tgz#0d6f6e5e413f8daaa26522904597be3d6cd93b51"
+  integrity sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ==
+  dependencies:
+    "@types/linkify-it" "*"
+    "@types/mdurl" "*"
+
+"@types/mdurl@*":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-1.0.2.tgz#e2ce9d83a613bacf284c7be7d491945e39e1f8e9"
+  integrity sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==
+
 "@types/minimatch@*":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"


### PR DESCRIPTION
Use markdown-it to parse the markdown, and use that to find headers.

This avoids bugs where you have codeblocks with line that start with `#` getting detected as headers.