### PR TITLE
Select codeblocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
       },
       {
         "command": "markdown-worklogs.copyCurrentCodeblock",
-        "title": "Markdown Work Logs: copy the text of the current codeblock"
+        "title": "Markdown Work Logs: copy the current codeblock to the clipboard"
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "markdown-worklogs",
   "displayName": "markdown-worklogs",
   "description": "Top-level TODO and DONE on your markdown headers",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "engines": {
     "vscode": "^1.64.0"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "onCommand:markdown-worklogs.gotoNextTopLevelHeader",
     "onCommand:markdown-worklogs.sortDoneToBottom",
     "onCommand:markdown-worklogs.sortCurrentDoneToBottom",
-    "onCommand:markdown-worklogs.findInWorklogs"
+    "onCommand:markdown-worklogs.findInWorklogs",
+    "onCommand:markdown-worklogs.copyCurrentCodeblock",
+    "onCommand:markdown-worklogs.selectCurrentCodeblock"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -123,6 +125,14 @@
       {
         "command": "markdown-worklogs.findInWorklogs",
         "title": "Markdown Work Logs: search in your worklogs"
+      },
+      {
+        "command": "markdown-worklogs.selectCurrentCodeblock",
+        "title": "Markdown Work Logs: select the current codeblock"
+      },
+      {
+        "command": "markdown-worklogs.copyCurrentCodeblock",
+        "title": "Markdown Work Logs: copy the text of the current codeblock"
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "lint:strict": "eslint src --ext ts --rule 'mocha/no-exclusive-tests: 2' --rule 'no-undef: 2' --rule 'no-console: 2'",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",
-    "package": "vsce package"
+    "package": "vsce package --no-yarn"
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -382,7 +382,6 @@ const moveDoneToBottom = async function (editor: vscode.TextEditor, params: { mi
 
 const currentCodeblock = (editor: vscode.TextEditor): Token | undefined => {
   const currentLine = editor.selection.active.line;
-  console.log(`looking for codeblocks at line ${currentLine}`);
   const parsed = getBlocks(editor);
   const codeblock = parsed.find(block => codeblockFilter(block, { currentLine }));
   return codeblock;
@@ -394,7 +393,6 @@ type CodeBlockFilterParams = {
 
 const codeblockFilter = (block: Token, params: CodeBlockFilterParams): boolean => {
   const { currentLine } = params;
-  console.log(`block type: ${block.type}`);
   if (block.type !== 'fence') {
     return false;
   }
@@ -402,17 +400,14 @@ const codeblockFilter = (block: Token, params: CodeBlockFilterParams): boolean =
     return false;
   }
   const [startLine, endLine] = block.map;
-  console.log(`current: ${currentLine}, start: ${startLine}, end: ${endLine}`);
   return startLine <= currentLine && endLine >= currentLine;
 };
 
 const copyCurrentCodeblock = async (editor: vscode.TextEditor) => {
   const codeblock = currentCodeblock(editor);
-  console.log(`current codeblock: ${JSON.stringify(codeblock)}`);
   if (!codeblock) {
     return;
   }
-  console.log(`content: ${codeblock.content}`);
   // const code = editor.document.getText(new vscode.Range(codeblock.start, codeblock.end));
   await vscode.env.clipboard.writeText(codeblock.content);
 };

--- a/src/test/fixtures/codeBlock.md
+++ b/src/test/fixtures/codeBlock.md
@@ -1,0 +1,7 @@
+# Fenced codeblocks
+
+```
+def foo
+  "foo"
+end
+```

--- a/src/test/fixtures/simple.md
+++ b/src/test/fixtures/simple.md
@@ -11,10 +11,10 @@
 Some text
 
 ```ruby
-# this is a comment, not a header
-def foo
-  'foo'
-end
+  # this is a comment, not a header
+  def foo
+    'foo'
+  end
 ```
 
 # 2

--- a/src/test/suite/codeblock.test.ts
+++ b/src/test/suite/codeblock.test.ts
@@ -1,0 +1,64 @@
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as helpers from '../helpers';
+
+describe('codeblock functions', function () {
+  let editor: vscode.TextEditor;
+
+  beforeEach(async function () {
+    editor = await helpers.openExample('codeBlock.md');
+  });
+
+  afterEach(async function () {
+    // we need to close the document so it gets reloaded fresh from the fixture for each test
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
+  });
+
+  describe('selectCurrentCodeblock', function () {
+    it('should select the contents if you are in the codeblock', async function () {
+      // put your cursor in the codeblock
+      helpers.gotoLine(editor, 4);
+      await vscode.commands.executeCommand("markdown-worklogs.selectCurrentCodeblock");
+
+      const s = editor.selection.start;
+      const e = editor.selection.end;
+      assert.strictEqual(JSON.stringify(s), '{"line":3,"character":0}');
+      assert.strictEqual(JSON.stringify(e), '{"line":5,"character":3}');
+    });
+
+    it('should do nothing if you are not in a codeblock', async function () {
+      // there is no codeblock on the first line
+      helpers.gotoLine(editor, 0);
+      await vscode.commands.executeCommand("markdown-worklogs.selectCurrentCodeblock");
+
+      const s = editor.selection.start;
+      const e = editor.selection.end;
+      assert.strictEqual(JSON.stringify(s), '{"line":0,"character":0}');
+      assert.strictEqual(JSON.stringify(e), '{"line":0,"character":0}');
+    });
+  });
+
+  describe('copyCurrentCodeblock', function () {
+    it('should copy the contents into the clipboard if you are in the codeblock', async function () {
+      // put your cursor in the codeblock
+      helpers.gotoLine(editor, 4);
+      await vscode.commands.executeCommand("markdown-worklogs.copyCurrentCodeblock");
+
+      const expectedText = 'def foo\n  "foo"\nend\n';
+      const clipboardText = await vscode.env.clipboard.readText();
+      assert.strictEqual(clipboardText, expectedText);
+    });
+
+    it('should leave the existing clipboard if you are not in the codeblock', async function () {
+      // There is no codeblock in the first line
+      helpers.gotoLine(editor, 0);
+      const expectedText = 'foo';
+      await vscode.env.clipboard.writeText(expectedText);
+      await vscode.commands.executeCommand("markdown-worklogs.copyCurrentCodeblock");
+
+      const clipboardText = await vscode.env.clipboard.readText();
+      assert.strictEqual(clipboardText, expectedText);
+    });
+  });
+});


### PR DESCRIPTION
Add two new functions

MarkdownWorklogs.copyCurrentCodeblock copies the text of the codeblock that your cursor is in to the clipboard

MarkdownWorklogs.selectCurrentCodeblock selects the text of the codeblock that your cursor is in.