### PR TITLE
Fix top done sorting

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -349,7 +349,7 @@ const moveDoneToBottom = async function (editor: vscode.TextEditor, params: { mi
   let doneEntries: [number, number][] = [];
   headers.forEach((header, n) => {
     const startLine = header.map?.[0];
-    if (!startLine) {
+    if (startLine === undefined || startLine === null) {
       return;
     }
     let endLine;

--- a/src/test/fixtures/sortable-sorted.md
+++ b/src/test/fixtures/sortable-sorted.md
@@ -1,5 +1,3 @@
-# TODO foo and bar
-this is some stufff
 # TODO whee
 and yeah
 ## DONE
@@ -7,6 +5,8 @@ I should be left under whee!
 # nothing at all
 to see here
 # TODO and here -- last non-done-line should be here, line 14
+# DONE foo and bar
+this is some stufff
 # DONE nice (2,3)
 and stuff
 # DONE foo (6,6)

--- a/src/test/fixtures/sortable-sorted.md
+++ b/src/test/fixtures/sortable-sorted.md
@@ -4,7 +4,7 @@ and yeah
 I should be left under whee!
 # nothing at all
 to see here
-# TODO and here -- last non-done-line should be here, line 14
+# TODO and here -- last non-done-line should be here, line 7
 # DONE foo and bar
 this is some stufff
 # DONE nice (2,3)

--- a/src/test/fixtures/sortable.md
+++ b/src/test/fixtures/sortable.md
@@ -12,5 +12,5 @@ and whatever yeah
 # nothing at all
 to see here
 # DONE bar (9, 9)
-# TODO and here -- last non-done-line should be here, line 14
+# TODO and here -- last non-done-line should be here, line 7
 # DONE baz (11, 12)

--- a/src/test/fixtures/sortable.md
+++ b/src/test/fixtures/sortable.md
@@ -1,4 +1,4 @@
-# TODO foo and bar
+# DONE foo and bar
 this is some stufff
 # DONE nice (2,3)
 and stuff


### PR DESCRIPTION
Fix a bug where "move all DONE to bottom" would ignore done items at the very top of the file.